### PR TITLE
Python 3 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DocRaptor Python Native Client Library
 
-This is a Python package for using [DocRaptor API](https://docraptor.com/documentation) to convert [HTML to PDF and XLSX](https://docraptor.com).
+This is a Python package for using [DocRaptor API](https://docraptor.com/documentation) to convert [HTML to PDF and XLSX](https://docraptor.com). It is compatible with Python 2 and Python 3.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Stuck? We're experts at using DocRaptor so please [email us](mailto:support@docr
 
 The majority of the code in this repo is generated using swagger-codegen on [docraptor.yaml](docraptor.yaml). You can modify this file and regenerate the client using `script/generate_language python`.
 
+The generated client needed a few fixes
+- Python3 was forcing all encoding to utf8 on binary data
+
 
 ## Release Process
 

--- a/docraptor/api_client.py
+++ b/docraptor/api_client.py
@@ -233,9 +233,12 @@ class ApiClient(object):
         if "file" == response_type:
             return self.__deserialize_file(response)
 
+        if "str" == response_type:
+            return response.data
+
         # fetch data from response object
         try:
-            data = json.loads(response.data)
+            data = json.loads(response.data.decode('utf8'))
         except ValueError:
             data = response.data
 

--- a/docraptor/rest.py
+++ b/docraptor/rest.py
@@ -165,11 +165,6 @@ class RESTClientObject(object):
 
         r = RESTResponse(r)
 
-        # In the python 3, the response.data is bytes.
-        # we need to decode it to string.
-        if sys.version_info > (3,):
-            r.data = r.data.decode('utf8')
-
         # log response body
         logger.debug("response body: %s" % r.data)
 

--- a/examples/async.py
+++ b/examples/async.py
@@ -40,17 +40,17 @@ try:
       file = open("/tmp/docraptor-python.pdf", "wb")
       file.write(doc_response)
       file.close
-      print "Wrote PDF to /tmp/docraptor-python.pdf"
+      print("Wrote PDF to /tmp/docraptor-python.pdf")
       break
     elif status_response.status == "failed":
-      print "FAILED"
-      print status_response
+      print("FAILED")
+      print(status_response)
       break
     else:
       time.sleep(1)
 
-except docraptor.rest.ApiException, error:
-  print error
-  print error.message
-  print error.code
-  print error.response_body
+except docraptor.rest.ApiException as error:
+  print(error)
+  print(error.message)
+  print(error.code)
+  print(error.response_body)

--- a/examples/sync.py
+++ b/examples/sync.py
@@ -35,10 +35,10 @@ try:
   file = open("/tmp/docraptor-python.pdf", "wb")
   file.write(create_response)
   file.close
-  print "Wrote PDF to /tmp/docraptor-python.pdf"
+  print("Wrote PDF to /tmp/docraptor-python.pdf")
 
-except docraptor.rest.ApiException, error:
-  print error
-  print error.message
-  print error.code
-  print error.response_body
+except docraptor.rest.ApiException as error:
+  print(error)
+  print(error.message)
+  print(error.code)
+  print(error.response_body)

--- a/script/test
+++ b/script/test
@@ -5,24 +5,26 @@ cd "`dirname \"$0\"`/.."
 cd test
 
 # check dependencies
-python --version > /dev/null     || (echo "python must be installed"; exit 1)
+python2 --version > /dev/null     || (echo "python2 must be installed"; exit 1)
+python3 --version > /dev/null     || (echo "python3 must be installed"; exit 1)
 virtualenv --version > /dev/null || (echo "virtualenv must be installed"; exit 1)
 
-rm -rf venv
-which virutualenv || pip install virtualenv
-virtualenv venv
-source venv/bin/activate
-pip install ../
+for version in 2 3; do
+  rm -rf venv
+  virtualenv --python=`which python$version` venv
+  source venv/bin/activate
+  pip install ../
 
-# runs a test file with PASS/FAIL message
-run_test() {
-  python $1 && echo "PASS $1" || (echo "FAIL $1"; exit 1)
-}
+  # runs a test file with PASS/FAIL message
+  run_test() {
+    python $1 && echo "PASS $1 (Python $version)" || (echo "FAIL $1 (Python $version)"; exit 1)
+  }
 
-if [ "$1" == "" ]; then
-  for test in $(ls *.py); do
-    run_test $test
-  done
-else
-  run_test $1.py
-fi
+  if [ "$1" == "" ]; then
+    for test in $(ls *.py); do
+      run_test $test
+    done
+  else
+    run_test $1.py
+  fi
+done

--- a/script/test
+++ b/script/test
@@ -10,10 +10,10 @@ python3 --version > /dev/null     || (echo "python3 must be installed"; exit 1)
 virtualenv --version > /dev/null || (echo "virtualenv must be installed"; exit 1)
 
 for version in 2 3; do
-  rm -rf venv
-  virtualenv --python=`which python$version` venv
-  source venv/bin/activate
-  pip install ../
+  rm -rf venv-$version
+  virtualenv --python=`which python$version` venv-$version
+  source venv-$version/bin/activate
+  pip install --upgrade ../
 
   # runs a test file with PASS/FAIL message
   run_test() {

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,1 +1,2 @@
-venv
+/venv
+/venv-*

--- a/test/file.py
+++ b/test/file.py
@@ -1,0 +1,16 @@
+import docraptor
+import shutil
+
+docraptor.configuration.username = "YOUR_API_KEY_HERE"
+# docraptor.configuration.debug = True
+doc_api = docraptor.DocApi()
+
+create_response = doc_api.create_doc({
+  "test": True,
+  "document_content": "<html><body>Hello World</body></html>",
+  "name": "docraptor-python.pdf",
+  "document_type": "pdf",
+})
+file = open("/tmp/docraptor-python.pdf", "wb")
+file.write(create_response)
+file.close

--- a/test/invalid_async.py
+++ b/test/invalid_async.py
@@ -20,5 +20,5 @@ for x in range(0, 30):
     exit(0)
   time.sleep(1)
 
-print "Exception expected, but not raised"
+print("Exception expected, but not raised")
 exit(1)

--- a/test/invalid_sync.py
+++ b/test/invalid_sync.py
@@ -12,9 +12,9 @@ try:
     "name":             "s" * 201,
     "document_type":    "pdf",
   })
-except docraptor.rest.ApiException, e:
+except docraptor.rest.ApiException as e:
   exit(0)
 
-print "Exception expected, but not raised"
+print("Exception expected, but not raised")
 exit(1)
 


### PR DESCRIPTION
Fixes #2

This branch changes how Swagger decodes responses by conditionally utf8 decoding strings only when JSON parsing is about to happen. We also add a bypass similar to Tempfile support for returning a `str` directly when requested.

So now Python 2 will return a `str` and Python 3 will return `bytes` which is unencoded form of a `str` in the latest Pythons. See [this](https://docs.python.org/3/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit).

It also explicitly tests Python 2 and Python 3 when using `script/test`. Previously it was whatever version of Python was installed.

It also adds an explicit test for file output as Python 3 will only write `bytes` to files. Since our examples show how to output files we want to ensure this works easily.